### PR TITLE
[fix] nazalog: 删除默认创建log目录的操作

### DIFF
--- a/pkg/nazalog/log.go
+++ b/pkg/nazalog/log.go
@@ -329,7 +329,7 @@ func newLogger(modOptions ...ModOption) (*logger, error) {
 	}
 	if l.core.option.Filename != "" {
 		dir := filepath.Dir(l.core.option.Filename)
-		if err = os.MkdirAll(dir, 0777); err != nil {
+		if fsinfo,err := os.Stat(dir); err != nil || !fsinfo.IsDir() {
 			return nil, err
 		}
 		if l.core.fp, err = os.OpenFile(l.core.option.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666); err != nil {


### PR DESCRIPTION
默认创建log目录是不必要的
出于安全考虑，可能目录已存在，但是权限属于root，而lalserver是运行在lalserver用户组下，权限被限制出现启动失败
建议让用户自行创建目录并决定它的权限配置